### PR TITLE
chore: correct homepage/git URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "entropy",
     "encryption"
   ],
-  "homepage": "http://www.github.com/okdistribute/niceware-eff",
+  "homepage": "http://www.github.com/okdistribute/niceware",
   "main": "lib/main.js",
   "devDependencies": {
     "browserify": "^16.5.0",
@@ -39,7 +39,7 @@
   "author": "yan <yan@mit.edu>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/okdistribute/niceware-eff.git"
+    "url": "git://github.com/okdistribute/niceware.git"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
You'll need to publish a new version to have the URLs updated on the registry; I also haven't modified the docs for now.